### PR TITLE
Fixed top navbar item color issue by adding 'important'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "solid-admin",
   "description": "A simple admin panel based on Vue.js and Bulma css framework.",
-  "version": "0.23.1",
+  "version": "0.23.2",
   "author": "M. Reza Zerehpoosh <ironcladgeek@hotmail.com>",
   "private": true,
   "scripts": {

--- a/src/assets/sass/style.scss
+++ b/src/assets/sass/style.scss
@@ -29,7 +29,7 @@ body {
   box-shadow: 0 3px 6px rgba(0, 0, 0, .3);
   height: $top-navbar-height;
   & a {
-    color: $top-navbar-link-color;
+    color: $top-navbar-link-color !important;
   }
 }
 


### PR DESCRIPTION
Top navbar items were not _white_ (#FFF) as supposed